### PR TITLE
Replace qmail with its living fork, notqmail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 * [Microsoft Word for Windows 1.1a](http://www.computerhistory.org/atchm/microsoft-research-license-agreement-msword-v-1-1a/)
 * [Microsoft Windows File Manager (WinFile)](https://github.com/Microsoft/winfile)
 * [Various Unix systems archived at the Unix Heritage Society](http://minnie.tuhs.org/cgi-bin/utree.pl)
-* [qmail](https://github.com/schmonz/qmail)
+* [notqmail](https://github.com/notqmail/notqmail)
 * [Zapcc](https://github.com/yrnkrn/zapcc)
 
 ### Fortran

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 * [Microsoft Word for Windows 1.1a](http://www.computerhistory.org/atchm/microsoft-research-license-agreement-msword-v-1-1a/)
 * [Microsoft Windows File Manager (WinFile)](https://github.com/Microsoft/winfile)
 * [Various Unix systems archived at the Unix Heritage Society](http://minnie.tuhs.org/cgi-bin/utree.pl)
-* [notqmail](https://github.com/notqmail/notqmail)
+* [notqmail](https://github.com/notqmail/notqmail) - The repo includes tags for various historical releases
 * [Zapcc](https://github.com/yrnkrn/zapcc)
 
 ### Fortran


### PR DESCRIPTION
The notqmail repo includes tags for various historical releases.