### PR TITLE
Fix Nastran readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@
 ### Fortran
 
 * [Colossal Cave Adventure](https://jerz.setonhill.edu/intfic/colossal-cave-adventure-source-code/)
-* [NASA Formula Translator (NasTran)](https://github.com/nasa/NASTRAN-95) 
+* [NASA STRucture ANalysis (NaStrAn)](https://github.com/nasa/NASTRAN-95) 
   
-  NASA Formula translator (NasTran) is the base of still used code (MSC Nastran and NX Nastran) for analyzing mainly structures (planes, rockets, trains, cars,...). [Fortran=Formula Translator]. Check out the corresponding [Wikipedia entry](https://en.m.wikipedia.org/wiki/Nastran) for more information
+  NASA STRucture ANalysis (NaStrAn) is the base of still used code (MSC Nastran and NX Nastran) for analyzing mainly structures (planes, rockets, trains, cars,...). Name is probably also inspired by [Fortran=Formula Translating System](https://en.wikipedia.org/wiki/Fortran). Check out the corresponding [Wikipedia entry](https://en.m.wikipedia.org/wiki/Nastran) for more information
 
 ### Pascal
 


### PR DESCRIPTION
I wrongly quoted Nastran as Nasa formula translator as a nod to Fortran. Seems NASA STRucture ANalysis is more correct.