### PR TITLE
add link to the source code of winamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@
 * [Zapcc](https://github.com/yrnkrn/zapcc)
 * [Winamp](https://github.com/WinampDesktop/winamp) - The source code of the iconic Windows media player from the 2000s.
 
-
-
 ### Fortran
 
 * [Colossal Cave Adventure](https://jerz.setonhill.edu/intfic/colossal-cave-adventure-source-code/)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@
 * [Various Unix systems archived at the Unix Heritage Society](http://minnie.tuhs.org/cgi-bin/utree.pl)
 * [notqmail](https://github.com/notqmail/notqmail) - The repo includes tags for various historical releases
 * [Zapcc](https://github.com/yrnkrn/zapcc)
+* [Winamp](https://github.com/WinampDesktop/winamp) - The source code of the iconic Windows media player from the 2000s.
+
+
 
 ### Fortran
 


### PR DESCRIPTION
The Winamp Legacy player source code is now open (https://x.com/winamp/status/1838585768870052117). At least kind of, but also at least worth taking a look at! (brought to attention by @raymyers)